### PR TITLE
Jwtトークンをクッキーからローカルストレージに変更。

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ go run main.go
 URL: https://bitbucket.org/liamstask/goose/src/master/
 
 ```
+// 最後まで終わるまで待つようにする。
+go install bitbucket.org/liamstask/goose/cmd/goose
+
 goose create AddSomeColumns sql
 goose: created db/migrations/20130106093224_AddSomeColumns.sql
 ```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ make bash-api
 go run main.go
 ```
 
+## Migrationコマンド
+
+使用しているGooseのDoc
+URL: https://bitbucket.org/liamstask/goose/src/master/
+
+```
+goose create AddSomeColumns sql
+goose: created db/migrations/20130106093224_AddSomeColumns.sql
+```
+
 Vue側
 ```
 make bash-app

--- a/docker/api/Dockerfile
+++ b/docker/api/Dockerfile
@@ -6,4 +6,4 @@ FROM golang:${GO_VERSION}-alpine
 RUN apk update && apk add git alpine-sdk
 
 # ワーキングディレクトリの設定
-WORKDIR /go/src
+WORKDIR /src/api

--- a/src/api/Controllers/LoginController.go
+++ b/src/api/Controllers/LoginController.go
@@ -27,14 +27,19 @@ type GenericResponse struct {
 }
 
 type AuthResponse struct {
-	RefreshToken string `json:"refresh_token"`
-	AccessToken  string `json:"access_token"`
-	Username     string `json:"username"`
+	RefreshToken string       `json:"refresh_token"`
+	AccessToken  string       `json:"access_token"`
+	User         ResponseUser `json:"user"`
 }
 
 type userFormData struct {
 	Email    string `json:"email"`
 	Password string `json:"password"`
+}
+
+type ResponseUser struct {
+	Id   int    `json:"id"`
+	Name string `json:"name"`
 }
 
 func Login(w http.ResponseWriter, request *http.Request) {
@@ -107,8 +112,7 @@ func Login(w http.ResponseWriter, request *http.Request) {
 	}
 	fmt.Println("checkPassword:")
 
-	userID := strconv.Itoa(user.Id)
-	accessToken, err := utils.GenerateAccessToken(userID)
+	accessToken, err := utils.GenerateAccessToken(user.Id)
 	if err != nil {
 		fmt.Println(accessToken)
 		fmt.Println(err)
@@ -119,7 +123,7 @@ func Login(w http.ResponseWriter, request *http.Request) {
 	}
 	fmt.Println("SexCode:")
 
-	refreshToken, err := utils.GenerateRefreshToken(userID, user.TokenHash)
+	refreshToken, err := utils.GenerateRefreshToken(user.Id, user.TokenHash)
 	if err != nil {
 		fmt.Println(accessToken)
 		fmt.Println(err)
@@ -133,7 +137,7 @@ func Login(w http.ResponseWriter, request *http.Request) {
 	data := &GenericResponse{
 		Status:  http.StatusOK,
 		Message: "Successfully logged in",
-		Data:    &AuthResponse{AccessToken: accessToken, RefreshToken: refreshToken, Username: user.Name},
+		Data:    &AuthResponse{AccessToken: accessToken, RefreshToken: refreshToken, User: ResponseUser{Id: user.Id, Name: user.Name}},
 	}
 	utils.ToJSON(data, w)
 }

--- a/src/api/Controllers/LoginController.go
+++ b/src/api/Controllers/LoginController.go
@@ -114,7 +114,6 @@ func Login(w http.ResponseWriter, request *http.Request) {
 		fmt.Println(err)
 		w.WriteHeader(http.StatusInternalServerError)
 		// data.ToJSON(&GenericError{Error: err.Error()}, w)
-		fmt.Println("cannot Convert SexCode")
 		//utils.ToJSON(&GenericResponse{Status: false, Message: "Unable to login the user. Please try again later"}, w)
 		return
 	}

--- a/src/api/Controllers/LoginController.go
+++ b/src/api/Controllers/LoginController.go
@@ -21,7 +21,7 @@ type Ping struct {
 
 // GenericResponse is the format of our response
 type GenericResponse struct {
-	Status  bool        `json:"status"`
+	Status  int         `json:"status"`
 	Message string      `json:"message"`
 	Data    interface{} `json:"data"`
 }
@@ -43,8 +43,6 @@ func Login(w http.ResponseWriter, request *http.Request) {
 	fmt.Println(w, h)
 	header := w.Header()
 	header.Set("Content-Type", "application/json")
-	header.Set("Access-Control-Allow-Credentials", "true")
-	header.Set("Access-Control-Allow-Headers", "Content-Type, withCredentials")
 	header.Set("Access-Control-Allow-Origin", "http://localhost:3000")
 	header.Set("Access-Control-Allow-Methods", "POST, OPTIONS")
 	// In case you don't have separate CORS middleware
@@ -78,11 +76,6 @@ func Login(w http.ResponseWriter, request *http.Request) {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println("data:")
-	fmt.Printf("%v\n", userData)
-	fmt.Printf("%v\n", userData.Email)
-	fmt.Printf("%v\n", userData.Password)
-	fmt.Println("data:")
 
 	reqEmail := userData.Email
 	reqPassword := userData.Password
@@ -132,38 +125,14 @@ func Login(w http.ResponseWriter, request *http.Request) {
 		fmt.Println(accessToken)
 		fmt.Println(err)
 		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Println("cannotStatusInternalServerError")
 		//utils.ToJSON(&GenericError{Error: err.Error()}, w)
 		//utils.ToJSON(&GenericResponse{Status: false, Message: "Unable to login the user. Please try again later"}, w)
 		return
 	}
-	fmt.Println("AccessToken:")
-
-	accessTokenCookie := &http.Cookie{
-		Name:     "accessToken", // <- should be any unique key you want
-		Value:    accessToken,   // <- the token after encoded by SecureCookie
-		Path:     "/",
-		Secure:   true,
-		HttpOnly: true,
-		SameSite: http.SameSiteNoneMode,
-		Domain:   "localhost",
-	}
-	http.SetCookie(w, accessTokenCookie)
-
-	refreshTokenCookie := &http.Cookie{
-		Name:     "refreshToken", // <- should be any unique key you want
-		Value:    refreshToken,   // <- the token after encoded by SecureCookie
-		Path:     "/",
-		Secure:   true,
-		HttpOnly: true,
-		SameSite: http.SameSiteNoneMode,
-		Domain:   "localhost",
-	}
-	http.SetCookie(w, refreshTokenCookie)
 
 	//utils.ToJSON(&AuthResponse{AccessToken: accessToken, RefreshToken: refreshToken, Username: user.Username}, w)
 	data := &GenericResponse{
-		Status:  true,
+		Status:  http.StatusOK,
 		Message: "Successfully logged in",
 		Data:    &AuthResponse{AccessToken: accessToken, RefreshToken: refreshToken, Username: user.Name},
 	}

--- a/src/api/Controllers/RefreshTokenController.go
+++ b/src/api/Controllers/RefreshTokenController.go
@@ -51,7 +51,7 @@ func CreateAccessTokenByRefreshToken(w http.ResponseWriter, request *http.Reques
 
 	// リフレッシュトークンが失効されていないかチェック。
 	disabled, _ := disabledRefreshTokenRepository.Exist(connection, refreshToken)
-	if disabled {
+	if !disabled {
 		utils.ToJSON(&GenericResponse{Status: 400, Message: "You are using disabled RefreshToken."}, w)
 		return
 	}

--- a/src/api/Controllers/RefreshTokenController.go
+++ b/src/api/Controllers/RefreshTokenController.go
@@ -1,0 +1,97 @@
+package Controllers
+
+import (
+	"api/db"
+	"api/infrastructure/disabledRefreshTokenRepository"
+	"api/infrastructure/userRepositopry"
+	"api/utils"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+type NewTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+/**
+ * 新しくリフレッシュトークンとアクセストークンを作成して返す
+ */
+func CreateAccessTokenByRefreshToken(w http.ResponseWriter, request *http.Request) {
+	header := w.Header()
+	header.Set("Content-Type", "application/x-www-form-urlencoded")
+	header.Set("Access-Control-Allow-Origin", "http://localhost:3000")
+	header.Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+	header.Set("Access-Control-Allow-Headers", "Authorization")
+
+	// In case you don't have separate CORS middleware
+	if request.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if err := request.ParseForm(); err != nil {
+		fmt.Println("errorだよ")
+	}
+
+	grantType := request.Form.Get("grant_type")
+	refreshToken := request.Form.Get("refresh_token")
+	fmt.Println("grantType", grantType)
+	fmt.Println("refreshToken", refreshToken)
+	if grantType != "refresh_token" {
+		utils.ToJSON(&GenericResponse{Status: 400, Message: "Invalid grant type."}, w)
+		return
+	}
+
+	connection, err := db.NewConnection()
+	if err != nil {
+		log.Fatalf("err:", err)
+	}
+
+	// リフレッシュトークンが失効されていないかチェック。
+	disabled, _ := disabledRefreshTokenRepository.Exist(connection, refreshToken)
+	if disabled {
+		utils.ToJSON(&GenericResponse{Status: 400, Message: "You are using disabled RefreshToken."}, w)
+		return
+	}
+
+	// 正しいリフレッシュトークンかチェック。
+	claims, err := utils.ValidateRefreshToken(refreshToken)
+	if err != nil {
+		utils.ToJSON(&GenericResponse{Status: 400, Message: "Authentication failed. Invalid token"}, w)
+		return
+	}
+
+	// 正しいuserIdかチェックする。
+	user, err := userRepositopry.FetchByUserId(connection, claims.UserID)
+	if err != nil && user.Id != claims.UserID {
+		utils.ToJSON(&GenericResponse{Status: 400, Message: "Invalid User."}, w)
+		return
+	}
+
+	// 使用したリフレッシュトークンを失効
+	disabledRefreshTokenRepository.AddDisabledRefreshToken(connection, refreshToken)
+	// 新しいリフレッシュトークンを作成
+	newRefreshToken, err := utils.GenerateRefreshToken(user.Id, user.TokenHash)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		utils.ToJSON(&GenericResponse{Status: http.StatusInternalServerError, Message: "Cannot Create RefreshToken"}, w)
+		return
+	}
+
+	// 新しいアクセストークンを作成
+	newAccessToken, err := utils.GenerateAccessToken(user.Id)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		utils.ToJSON(&GenericResponse{Status: http.StatusInternalServerError, Message: "Cannot Create RefreshToken"}, w)
+		return
+	}
+	// 作成した新しいトークンを返す
+	data := &GenericResponse{
+		Status:  http.StatusOK,
+		Message: "Create New RefreshToken",
+		Data:    &NewTokenResponse{AccessToken: newAccessToken, RefreshToken: newRefreshToken},
+	}
+	utils.ToJSON(data, w)
+}

--- a/src/api/Controllers/RootController.go
+++ b/src/api/Controllers/RootController.go
@@ -1,8 +1,6 @@
 package Controllers
 
 import (
-	"context"
-	"fmt"
 	"net/http"
 )
 

--- a/src/api/Controllers/RootController.go
+++ b/src/api/Controllers/RootController.go
@@ -1,6 +1,8 @@
 package Controllers
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 )
 
@@ -9,11 +11,10 @@ import (
  */
 func Root(w http.ResponseWriter, request *http.Request) {
 	header := w.Header()
-	header.Set("Content-Type", "application/json")
-	header.Set("Access-Control-Allow-Credentials", "true")
-	header.Set("Access-Control-Allow-Headers", "Content-Type, withCredentials")
 	header.Set("Access-Control-Allow-Origin", "http://localhost:3000")
-	header.Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	header.Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+	header.Set("Access-Control-Allow-Headers", "Authorization")
+
 	// In case you don't have separate CORS middleware
 	if request.Method == http.MethodOptions {
 		w.WriteHeader(http.StatusOK)

--- a/src/api/Middleware/AuthMiddleware.go
+++ b/src/api/Middleware/AuthMiddleware.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
+	"time"
 
 	"api/utils"
 )
@@ -13,12 +15,12 @@ type UserIDKey struct{}
 
 // Define our struct
 type AuthMiddleware struct {
-	cookieAccessToken string
+	accessToken string
 }
 
 // Initialize it somewhere
 func (amw *AuthMiddleware) Initialize() {
-	amw.cookieAccessToken = ""
+	amw.accessToken = ""
 }
 
 type GenericResponse struct {
@@ -30,20 +32,28 @@ type GenericResponse struct {
 // Middleware function, which will be called for each request
 func (amw *AuthMiddleware) ValidateAccessToken(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if amw.cookieAccessToken != "" {
+		if amw.accessToken != "" {
 			//Initializeされた後に使われるので、ここでエラーを出す
 		}
+		reqToken := r.Header.Get("Authorization")
+		splitToken := strings.Split(reqToken, "Bearer ")
+		reqToken = splitToken[1]
 
-		// クッキーからアクセストークンを取得
-		cookie, err := utils.GetToken(r)
-		if err != nil {
-			http.Error(w, "Cookie not found", http.StatusForbidden)
-			utils.ToJSON(&GenericResponse{Status: false, Message: "Cookie not found"}, w)
-			return
+		amw.accessToken = reqToken
+		claims, err := utils.ValidateAccessToken(amw.accessToken)
+
+		fmt.Println("jwtToken", claims.ExpiresAt)
+		fmt.Println("Unix", time.Now().Unix())
+		// アクセストークンを新しくするかどうかのフラグをセット
+		//var refreshTokenContext context.Context = context.WithValue(r.Context(), "refreshAccessToken", false)
+		var refreshTokenContext context.Context = context.WithValue(r.Context(), "refreshAccessToken", false)
+		r = r.WithContext(refreshTokenContext)
+		// もし、トークンの有効期限が切れていたら、新しくアクセストークンを作成するようにフラグをセット
+		if claims.ExpiresAt < time.Now().Unix() {
+			refreshTokenContext = context.WithValue(r.Context(), "refreshAccessToken", true)
+			r = r.WithContext(refreshTokenContext)
 		}
-		amw.cookieAccessToken = cookie
-		fmt.Println(amw.cookieAccessToken)
-		userID, err := utils.ValidateAccessToken(amw.cookieAccessToken)
+
 		if err != nil {
 			// data.ToJSON(&GenericError{Error: err.Error()}, w)
 			utils.ToJSON(&GenericResponse{Status: false, Message: "Authentication failed. Invalid token"}, w)
@@ -52,7 +62,7 @@ func (amw *AuthMiddleware) ValidateAccessToken(next http.Handler) http.Handler {
 
 		// r.Context().Value()でユーザーIDを取得できるようにContextにセットしておく。
 		// 参考になりそうな記事：https://medium.com/@agatan/http%E3%82%B5%E3%83%BC%E3%83%90%E3%81%A8context-context-7211433d11e6
-		ctx := context.WithValue(r.Context(), UserIDKey{}, userID)
+		ctx := context.WithValue(r.Context(), UserIDKey{}, claims.UserID)
 		r = r.WithContext(ctx)
 
 		// 問題なければ、次に進める

--- a/src/api/Middleware/AuthMiddleware.go
+++ b/src/api/Middleware/AuthMiddleware.go
@@ -42,24 +42,11 @@ func (amw *AuthMiddleware) ValidateAccessToken(next http.Handler) http.Handler {
 		amw.accessToken = reqToken
 		claims, err := utils.ValidateAccessToken(amw.accessToken)
 
-		fmt.Println("jwtToken", claims.ExpiresAt)
-		fmt.Println("Unix", time.Now().Unix())
-		// アクセストークンを新しくするかどうかのフラグをセット
-		//var refreshTokenContext context.Context = context.WithValue(r.Context(), "refreshAccessToken", false)
-		var refreshTokenContext context.Context = context.WithValue(r.Context(), "refreshAccessToken", false)
-		r = r.WithContext(refreshTokenContext)
-		// もし、トークンの有効期限が切れていたら、新しくアクセストークンを作成するようにフラグをセット
-		if claims.ExpiresAt < time.Now().Unix() {
-			refreshTokenContext = context.WithValue(r.Context(), "refreshAccessToken", true)
-			r = r.WithContext(refreshTokenContext)
-		}
-
 		if err != nil {
 			// data.ToJSON(&GenericError{Error: err.Error()}, w)
 			utils.ToJSON(&GenericResponse{Status: false, Message: "Authentication failed. Invalid token"}, w)
 			return
 		}
-
 		// r.Context().Value()でユーザーIDを取得できるようにContextにセットしておく。
 		// 参考になりそうな記事：https://medium.com/@agatan/http%E3%82%B5%E3%83%BC%E3%83%90%E3%81%A8context-context-7211433d11e6
 		ctx := context.WithValue(r.Context(), UserIDKey{}, claims.UserID)

--- a/src/api/db/migrations/20210925082043_CreateDisabledRefreshToken.sql
+++ b/src/api/db/migrations/20210925082043_CreateDisabledRefreshToken.sql
@@ -1,0 +1,14 @@
+
+-- +goose Up
+-- SQL in section 'Up' is executed when this migration is applied
+CREATE TABLE `disabled_refresh_token_tbl` (
+    `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+    `refresh_token` text NOT NULL,
+    `created_at` timestamp NULL DEFAULT NULL,
+    `updated_at` timestamp NULL DEFAULT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='執行されたリフレッシュトークンのリストを保存するテーブル';
+
+-- +goose Down
+-- SQL section 'Down' is executed when this migration is rolled back
+DROP TABLE IF EXISTS `disabled_refresh_token_tbl`;

--- a/src/api/infrastructure/disabledRefreshTokenRepository/disabledRefreshToken.go
+++ b/src/api/infrastructure/disabledRefreshTokenRepository/disabledRefreshToken.go
@@ -1,0 +1,8 @@
+package disabledRefreshTokenRepository
+
+type DisabledRefreshToken struct {
+	Id           int
+	RefreshToken string
+	CreatedAt    string
+	UpdatedAt    string
+}

--- a/src/api/infrastructure/disabledRefreshTokenRepository/repository.go
+++ b/src/api/infrastructure/disabledRefreshTokenRepository/repository.go
@@ -1,0 +1,60 @@
+package disabledRefreshTokenRepository
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"time"
+)
+
+const disabledRefreshTokenTableName string = "disabled_refresh_token_tbl"
+
+func AddDisabledRefreshToken(db *sql.DB, refreshToken string) (bool, error) {
+	dateTimeFormat := "2006-01-02 15:04:05"
+	dateTime := time.Now().Format(dateTimeFormat)
+	columns := "(refresh_token, created_at, updated_at)"
+
+	sqlQuery, _ := db.Prepare("INSERT INTO " + disabledRefreshTokenTableName + " " + columns + " VALUES (?,?,?)")
+	// execute query
+	_, err := sqlQuery.Exec(
+		refreshToken,
+		dateTime,
+		dateTime,
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	return true, nil
+}
+
+func Exist(db *sql.DB, refreshToken string) (bool, error) {
+	var sql string = "SELECT count(id) FROM " + disabledRefreshTokenTableName + " WHERE refresh_token = ?"
+	stmt, err := db.Prepare(sql)
+	if err != nil {
+		return false, err
+	}
+	// 遅延処理の実行
+	defer stmt.Close()
+	rows, err := stmt.Query(refreshToken)
+	if err != nil {
+		return false, err
+	}
+	// 遅延処理の実行
+	defer rows.Close()
+
+	var count int
+	for rows.Next() {
+		if err := rows.Scan(&count); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	fmt.Printf("Number of rows are %s\n", count)
+
+	if count < 0 {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/src/api/infrastructure/userRepositopry/userRepositopry.go
+++ b/src/api/infrastructure/userRepositopry/userRepositopry.go
@@ -77,3 +77,51 @@ func FetchByEmail(db *sql.DB, email string) (*User, error) {
 
 	return &user, nil
 }
+
+func FetchByUserId(db *sql.DB, userId int) (*User, error) {
+	var sql string = "SELECT * FROM " + userTableName + " WHERE id = ?"
+	stmt, err := db.Prepare(sql)
+	if err != nil {
+		return nil, err
+	}
+	// 遅延処理の実行
+	defer stmt.Close()
+	rows, err := stmt.Query(userId)
+	if err != nil {
+		return nil, err
+	}
+	// 遅延処理の実行
+	defer rows.Close()
+
+	var user User
+	for rows.Next() {
+		// Goではループの終了後に、必ずエラーチェックを行う。
+		// 全ての行が処理されるまで、ループが継続されるとは限らないため。
+		// &形式で指定する。
+		//  Scan error on column index 0, name "id": destination not a pointerのエラーが出るため
+		err := rows.Scan(
+			&user.Id,
+			&user.Name,
+			&user.Email,
+			&user.PasswordHash,
+			&user.TokenHash,
+			&user.SexCode,
+			&user.PrefCode,
+			&user.CityCode,
+			&user.WardCode,
+			&user.RememberToken,
+			&user.CreatedAt,
+			&user.UpdatedAt,
+			&user.DeletedAt,
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	err = rows.Err()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return &user, nil
+}

--- a/src/api/main.go
+++ b/src/api/main.go
@@ -18,6 +18,9 @@ func main() {
 	router.HandleFunc("/login", Controllers.Login).Methods("POST")
 	router.HandleFunc("/login", Controllers.Login).Methods("OPTIONS")
 
+	postRouter := router.Methods(http.MethodPost).Subrouter()
+	postRouter.HandleFunc("/refresh-token", Controllers.CreateAccessTokenByRefreshToken)
+
 	optionsRouter := router.Methods(http.MethodOptions).Subrouter()
 	optionsRouter.HandleFunc("/", Controllers.Root)
 

--- a/src/api/main.go
+++ b/src/api/main.go
@@ -28,7 +28,6 @@ func main() {
 	//cors optionsGoes Below
 	c := cors.New(cors.Options{
 		AllowedOrigins:     []string{"http://localhost:3000"}, // All origins
-		AllowCredentials:   true,                              // Cookieを共有できるようにセットしておく。
 		AllowedMethods:     []string{"GET", "POST", "OPTIONS"},
 		OptionsPassthrough: true,
 	})

--- a/src/api/utils/token.go
+++ b/src/api/utils/token.go
@@ -49,7 +49,7 @@ func GenerateRandomString(n int) string {
 }
 
 // アクセストークンの生成
-func GenerateAccessToken(userID string) (string, error) {
+func GenerateAccessToken(userID int) (string, error) {
 	tokenType := "access"
 	tokenExpiredTime, _ := strconv.ParseInt(os.Getenv("JWT_EXPIRATION"), 10, 64)
 	accessTokenKeyPath := os.Getenv("ACCESS_TOKEN_PRIVATE_KEY")
@@ -78,7 +78,7 @@ func GenerateAccessToken(userID string) (string, error) {
 	return accessToken, err
 }
 
-func GenerateRefreshToken(userId string, tokenHash string) (string, error) {
+func GenerateRefreshToken(userId int, tokenHash string) (string, error) {
 	cusKey := generateCustomKey(userId, tokenHash)
 	tokenType := "refresh"
 	accessTokenKeyPath := os.Getenv("ACCESS_TOKEN_PRIVATE_KEY")

--- a/src/api/utils/token.go
+++ b/src/api/utils/token.go
@@ -24,6 +24,7 @@ import (
 type AccessTokenCustomClaims struct {
 	UserID  int
 	KeyType string
+	Exp     int64
 	jwt.StandardClaims
 }
 
@@ -32,6 +33,7 @@ type RefreshTokenCustomClaims struct {
 	UserID    int
 	CustomKey string
 	KeyType   string
+	Exp       int64
 	jwt.StandardClaims
 }
 
@@ -51,13 +53,15 @@ func GenerateRandomString(n int) string {
 // アクセストークンの生成
 func GenerateAccessToken(userID int) (string, error) {
 	tokenType := "access"
-	tokenExpiredTime, _ := strconv.ParseInt(os.Getenv("JWT_EXPIRATION"), 10, 64)
+	tokenExpiredTime, _ := strconv.ParseInt(os.Getenv("JWT_ACCESS_TOKEN_EXPIRATION"), 10, 64)
+	expiredTime := time.Now().Add(time.Minute * time.Duration(tokenExpiredTime)).Unix()
 	accessTokenKeyPath := os.Getenv("ACCESS_TOKEN_PRIVATE_KEY")
 	claims := AccessTokenCustomClaims{
 		userID,
 		tokenType,
+		expiredTime,
 		jwt.StandardClaims{
-			ExpiresAt: time.Now().Add(time.Minute * time.Duration(tokenExpiredTime)).Unix(),
+			ExpiresAt: expiredTime,
 			Issuer:    "go-typescript-board.auth.service",
 		},
 	}
@@ -82,11 +86,14 @@ func GenerateRefreshToken(userId int, tokenHash string) (string, error) {
 	cusKey := generateCustomKey(userId, tokenHash)
 	tokenType := "refresh"
 	accessTokenKeyPath := os.Getenv("ACCESS_TOKEN_PRIVATE_KEY")
+	tokenExpiredTime, _ := strconv.ParseInt(os.Getenv("JWT_REFRESH_TOKEN_EXPIRATION"), 10, 64)
+	expiredTime := time.Now().Add(time.Minute * time.Duration(tokenExpiredTime)).Unix()
 
 	claims := RefreshTokenCustomClaims{
 		userId,
 		cusKey,
 		tokenType,
+		expiredTime,
 		jwt.StandardClaims{
 			Issuer: "go-typescript-board.auth.service",
 		},

--- a/src/api/utils/token.go
+++ b/src/api/utils/token.go
@@ -108,11 +108,11 @@ func GenerateRefreshToken(userId string, tokenHash string) (string, error) {
 	return accessToken, err
 }
 
-func generateCustomKey(userID string, tokenHash string) string {
+func generateCustomKey(userID int, tokenHash string) string {
 
-	// data := userID + tokenHash
+	strUserId := strconv.Itoa(userID)
 	h := hmac.New(sha256.New, []byte(tokenHash))
-	h.Write([]byte(userID))
+	h.Write([]byte(strUserId))
 	sha := hex.EncodeToString(h.Sum(nil))
 	return sha
 }
@@ -208,7 +208,7 @@ func ValidateAccessToken(tokenString string) (*AccessTokenCustomClaims, error) {
 
 	claims, ok := token.Claims.(*AccessTokenCustomClaims)
 
-	if !ok || !token.Valid || claims.UserID == "" || claims.KeyType != "access" {
+	if !ok || !token.Valid || claims.UserID == 0 || claims.KeyType != "access" {
 		return nil, errors.New("invalid token: authentication failed")
 	}
 

--- a/src/api/utils/token.go
+++ b/src/api/utils/token.go
@@ -22,14 +22,14 @@ import (
 
 // アクセストークンで必要な要素
 type AccessTokenCustomClaims struct {
-	UserID  string
+	UserID  int
 	KeyType string
 	jwt.StandardClaims
 }
 
 // リフレッシュトークンで必要な要素
 type RefreshTokenCustomClaims struct {
-	UserID    string
+	UserID    int
 	CustomKey string
 	KeyType   string
 	jwt.StandardClaims

--- a/src/app/src/app/composables/auth/auth.ts
+++ b/src/app/src/app/composables/auth/auth.ts
@@ -1,29 +1,60 @@
-import axios from "axios";
+import {createNewAccessToken} from "../jwt/jwt";
+import {onBeforeMount} from 'vue'
 
-export const checkAuth = async () => {
-    let result: boolean = false
-    try {
-        // Set config defaults when creating the instance
-        const instance = axios.create({
-            baseURL: 'http://localhost:8000/',
-            headers: {
-                "Authorization": `Bearer ${localStorage.getItem('accessToken')}`,
-                "Content-Type": "application/json",
-            },
-            data: {}
-        });
-        const response = await instance.get('/')
-        result = true
-        console.log(response);
-    } catch (error) {
-        result = false
-        console.log(error);
+export const checkAuth = () => {
+    onBeforeMount(async () => {
+        const accessJwtToken: string | null = localStorage.getItem('accessToken')
+        const refreshJwtToken: string | null = localStorage.getItem('refreshToken')
+        if (!accessJwtToken || accessJwtToken === "undefined" || !refreshJwtToken || refreshJwtToken === "undefined") {
+            // 各トークンが存在しない場合は、ログイン画面へリダイレクト
+            location.href = '/login'
+            return
+        }
+        const accessToken = decodeJwt(accessJwtToken)
+        if (isExpiredAccessToken(accessToken.exp)) {
+            // トークンの有効期限が切れていた場合は、新しくアクセストークンを取り直す
+            const result = await createNewAccessToken()
+            if (!result) {
+                // もしトークンが取れなかった場合は、各ストレージの値を空にした上で、ログイン画面へリダイレクト
+                localStorage.removeItem('accessToken')
+                localStorage.removeItem('refreshToken')
+                location.href = '/login'
+                return
+            }
+        }
+    })
+}
+
+/**
+ * Jwtのコードをデコードする。
+ * @param token
+ */
+const decodeJwt = (token: string) => {
+    const base64Url = token.split('.')[1];
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const jsonPayload = decodeURIComponent(atob(base64).split('').map(function(c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+    }).join(''));
+
+    return JSON.parse(jsonPayload);
+}
+
+/**
+ * アクセストークンの有効期限をチェックする
+ * 有効期限が切れていた場合は、trueを返す
+ * @param expiredTime
+ */
+const isExpiredAccessToken = (expiredTime: number) => {
+    // Dateオブジェクトを作成
+    const dateObject: Date = new Date() ;
+    // 一度ミリ秒単位で、UNIXタイムスタンプを取得する
+    const milliSecondTimeStamp: number = dateObject.getTime() ;
+    // そのあと、秒単位UNIXタイムスタンプを生成
+    const secondTimeStamp: number = Math.floor( milliSecondTimeStamp / 1000 ) ;
+
+    if (expiredTime > secondTimeStamp) {
+        return false
     }
 
-    if (!result) {
-        // location.href = 'login'
-        // return
-    }
-
-    return {result}
+    return true
 }

--- a/src/app/src/app/composables/auth/auth.ts
+++ b/src/app/src/app/composables/auth/auth.ts
@@ -3,10 +3,16 @@ import axios from "axios";
 export const checkAuth = async () => {
     let result: boolean = false
     try {
-        const options = {
-            withCredentials: true,
-        };
-        const response = await axios.get('http://localhost:8000/', options)
+        // Set config defaults when creating the instance
+        const instance = axios.create({
+            baseURL: 'http://localhost:8000/',
+            headers: {
+                "Authorization": `Bearer ${localStorage.getItem('accessToken')}`,
+                "Content-Type": "application/json",
+            },
+            data: {}
+        });
+        const response = await instance.get('/')
         result = true
         console.log(response);
     } catch (error) {
@@ -15,8 +21,8 @@ export const checkAuth = async () => {
     }
 
     if (!result) {
-        location.href = 'login'
-        return
+        // location.href = 'login'
+        // return
     }
 
     return {result}

--- a/src/app/src/app/composables/jwt/jwt.ts
+++ b/src/app/src/app/composables/jwt/jwt.ts
@@ -1,0 +1,35 @@
+import axios from "axios";
+
+export const createNewAccessToken = async () => {
+    let result: boolean
+    const refreshToken: string | null = localStorage.getItem('refreshToken')
+    if (refreshToken === null) {
+        return
+    }
+    const params: URLSearchParams = new URLSearchParams();
+    params.append('grant_type', 'refresh_token');
+    params.append('refresh_token', refreshToken);
+
+    try {
+        // Set config defaults when creating the instance
+        const instance = axios.create({
+            baseURL: 'http://localhost:8000/',
+            headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            params: params,
+        });
+        const response = await instance.post('/refresh-token')
+        const accessToken: string = response.data.access_token
+        const refreshToken: string = response.data.refresh_token
+
+        localStorage.setItem('accessToken', accessToken)
+        localStorage.setItem('refreshToken', refreshToken)
+        result = true
+    } catch (error) {
+        console.log(error);
+        result = false
+    }
+
+    return {result}
+}

--- a/src/app/src/app/composables/jwt/jwt.ts
+++ b/src/app/src/app/composables/jwt/jwt.ts
@@ -4,7 +4,7 @@ export const createNewAccessToken = async () => {
     let result: boolean
     const refreshToken: string | null = localStorage.getItem('refreshToken')
     if (refreshToken === null) {
-        return
+        return false
     }
     const params: URLSearchParams = new URLSearchParams();
     params.append('grant_type', 'refresh_token');
@@ -20,16 +20,16 @@ export const createNewAccessToken = async () => {
             params: params,
         });
         const response = await instance.post('/refresh-token')
-        const accessToken: string = response.data.access_token
-        const refreshToken: string = response.data.refresh_token
-
+        const accessToken: string = response.data.data.access_token
+        const refreshToken: string = response.data.data.refresh_token
         localStorage.setItem('accessToken', accessToken)
         localStorage.setItem('refreshToken', refreshToken)
+
         result = true
     } catch (error) {
         console.log(error);
         result = false
     }
 
-    return {result}
+    return result
 }

--- a/src/app/src/app/pages/Login/index.vue
+++ b/src/app/src/app/pages/Login/index.vue
@@ -52,8 +52,10 @@ export default defineComponent({
       }
       axios.post('http://localhost:8000/login', data).then(function (response) {
         const result = response.data
-        console.log(result);
-        if (result.status) {
+        console.log(result.data.refresh_token);
+        if (result.status === 200) {
+          localStorage.setItem('accessToken', result.data.access_token)
+          localStorage.setItem('refreshToken', result.data.refresh_token)
           //location.href = '/'
         }
       })

--- a/src/app/src/app/pages/Login/index.vue
+++ b/src/app/src/app/pages/Login/index.vue
@@ -52,11 +52,12 @@ export default defineComponent({
       }
       axios.post('http://localhost:8000/login', data).then(function (response) {
         const result = response.data
-        console.log(result.data.refresh_token);
+        console.log(result.data);
         if (result.status === 200) {
           localStorage.setItem('accessToken', result.data.access_token)
           localStorage.setItem('refreshToken', result.data.refresh_token)
-          //location.href = '/'
+          localStorage.setItem('user', result.data.user)
+          location.href = '/'
         }
       })
     }

--- a/src/app/src/app/pages/Login/index.vue
+++ b/src/app/src/app/pages/Login/index.vue
@@ -29,9 +29,6 @@
                 </button>
               </div>
             </form>
-            <button class="button is-success" @click="sendGetRequest">
-              GET REQUEST
-            </button>
           </div>
         </div>
       </div>
@@ -48,6 +45,7 @@ export default defineComponent({
     const err = false
 
     const sendRequest = () => {
+      // TODO: あとで、フォームの値をバインドする。
       const data = {
         email: 'test@example.com',
         password: 'test',
@@ -60,20 +58,9 @@ export default defineComponent({
         }
       })
     }
-
-    const sendGetRequest = () => {
-      const options = {
-        withCredentials: true,
-      };
-      axios.get('http://localhost:8000/gets', options).then(function (response) {
-        console.log('FFFFFFFF');
-        console.log(response.data);
-      })
-    }
     return {
       err,
       sendRequest,
-      sendGetRequest,
     }
   },
 })

--- a/src/app/src/app/pages/Login/index.vue
+++ b/src/app/src/app/pages/Login/index.vue
@@ -52,14 +52,11 @@ export default defineComponent({
         email: 'test@example.com',
         password: 'test',
       }
-      const options = {
-        withCredentials: true,
-      };
-      axios.post('http://localhost:8000/login', data, options).then(function (response) {
+      axios.post('http://localhost:8000/login', data).then(function (response) {
         const result = response.data
-        console.log(result.status);
+        console.log(result);
         if (result.status) {
-          location.href = '/'
+          //location.href = '/'
         }
       })
     }

--- a/src/app/src/app/pages/index.vue
+++ b/src/app/src/app/pages/index.vue
@@ -1,12 +1,14 @@
 <template>
   <section class="hero is-primary is-fullheight">
     <p>Your are Logged IN !!!</p>
+    <button @click="createNewAccessToken">Send Request</button>
   </section>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue'
 import {checkAuth} from "../composables/auth/auth";
+import {createNewAccessToken} from "../composables/jwt/jwt";
 
 export default defineComponent({
   setup: () => {
@@ -14,6 +16,7 @@ export default defineComponent({
     checkAuth();
 
     return {
+      createNewAccessToken,
       err,
     }
   },

--- a/src/app/src/app/pages/index.vue
+++ b/src/app/src/app/pages/index.vue
@@ -1,6 +1,6 @@
 <template>
   <section class="hero is-primary is-fullheight">
-    <p>Your are Logged IN !!</p>
+    <p>Your are Logged IN !!!</p>
   </section>
 </template>
 


### PR DESCRIPTION
- アクセストークンとリフレッシュトークンをローカルストレージに保存。
- アクセストークンの期限を設定して、それが切れるまではフロントでトークンがあるかどうかのみを見る。
- 期限が切れていたら、リフレッシュトークンを使って新しくアクセストークンを作成。
- ローカルストレージに入れている以上、リフレッシュトークンを使って新しくアクセストークンを生成した場合は、新しくリフレッシュトークンを作成。
- リフレッシュトークンも盗まれるなどして、本人がリフレッシュトークンを生成時一度使われていた場合は、該当のユーザーを全てログアウト。
- サイド各トークンを生成。
- UXの観点から、本人がログアウトしない限り、ずっとログイン状態